### PR TITLE
feat: Enhance scene loading with parent scope management

### DIFF
--- a/Runtime/Scopes/MonoBehaviourScopeBase.cs
+++ b/Runtime/Scopes/MonoBehaviourScopeBase.cs
@@ -133,24 +133,28 @@ namespace NestedDIContainer.Unity.Runtime.Core
         // ISceneLoader implementation -----
         void ISceneScopeLoader.LoadScene<TConfig>(Action loadSceneAction, TConfig config = null) where TConfig : class
         {
+            ProjectScope.PushParentId(ScopeId);
             ProjectScope.PushConfig(config);
             loadSceneAction();
         }
 
         async UniTask ISceneScopeLoader.LoadSceneAsync<TConfig>(Func<CancellationToken, UniTask> loadSceneFunc, CancellationToken cancellationToken, TConfig config = null) where TConfig : class
         {
+            ProjectScope.PushParentId(ScopeId);
             ProjectScope.PushConfig(config);
             await loadSceneFunc(cancellationToken);
         }
 
         async UniTask ISceneScopeLoader.LoadSceneAsync<TConfig>(string sceneName, LoadSceneMode loadSceneMode, CancellationToken cancellationToken, TConfig config = null) where TConfig : class
         {
+            ProjectScope.PushParentId(ScopeId);
             ProjectScope.PushConfig(config);
             await SceneManager.LoadSceneAsync(sceneName, loadSceneMode).ToUniTask(cancellationToken: cancellationToken);
         }
 
         void ISceneScopeLoader.LoadScene<TConfig>(string sceneName, LoadSceneMode loadSceneMode, TConfig config = null) where TConfig : class
         {
+            ProjectScope.PushParentId(ScopeId);
             ProjectScope.PushConfig(config);
             SceneManager.LoadScene(sceneName, loadSceneMode);
         }

--- a/Runtime/Scopes/ProjectScope.cs
+++ b/Runtime/Scopes/ProjectScope.cs
@@ -44,6 +44,18 @@ namespace NestedDIContainer.Unity.Runtime
             _tempConfig = config;
         }
         private static object _tempConfig = null;
+
+        internal static ScopeId? PopParentId()
+        {
+           var temp = _tempParentId;
+            _tempParentId = null;
+            return temp;
+        }
+        internal static void PushParentId(ScopeId parentId)
+        {
+            _tempParentId = parentId;
+        }
+        private static ScopeId? _tempParentId = null;
         
         protected void Awake()
         {

--- a/Runtime/Scopes/SceneScope.cs
+++ b/Runtime/Scopes/SceneScope.cs
@@ -17,8 +17,10 @@ namespace NestedDIContainer.Unity.Runtime
         {
             // Init ScopeId
             ScopeId = ScopeId.Create();
-            var parentScope = ProjectScope.Scope ?? ProjectScope.CreateProjectScope();
-            ParentScopeId = ScopeId.Equals(parentScope.ScopeId) ? ScopeId.Create() : parentScope.ScopeId;
+            var parentScope = ProjectScope.PopParentId() ?? ProjectScope.Scope?.ScopeId ?? ProjectScope.CreateProjectScope().ScopeId;
+            ParentScopeId = ScopeId.Equals(parentScope) 
+                ? ScopeId.Create()
+                : parentScope;
 
             ConstructScope(ScopeId, ParentScopeId.Value, ProjectScope.PopConfig(), new SceneScopeDefaultExtendScope(this));
         }


### PR DESCRIPTION
Added functionality to manage parent scope IDs during scene loading operations in MonoBehaviourScopeBase. Introduced methods to push and pop parent IDs in ProjectScope, ensuring proper scope hierarchy is maintained when loading scenes synchronously and asynchronously.